### PR TITLE
Use std::string for Protein name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore build arfifacts
+*.o
+*test
+metal
+podock
+

--- a/protein.cpp
+++ b/protein.cpp
@@ -11,8 +11,7 @@
 using namespace std;
 
 Protein::Protein(const char* lname)
-{	name = new char[strlen(lname)+1]{};
-	strcpy(name, lname);
+{	name = lname;
 	aaptrmin.n = aaptrmax.n = 0;
 }
 

--- a/protein.h
+++ b/protein.h
@@ -4,6 +4,8 @@
 #ifndef _PROTEIN
 #define _PROTEIN
 
+#include <string>
+
 void ext_mtl_coord_cnf_cb(int iter);
 
 class Protein
@@ -67,7 +69,7 @@ class Protein
 	int* mcoord_resnos = NULL;
 	
 	protected:
-	char* name=0;
+	std::string name;
 	char* sequence=0;
 	AminoAcid** residues=0;
 	AminoAcid*** res_can_coll = 0;


### PR DESCRIPTION
Hey podock maintainer! Stumbled upon your podock repo, and really liked the philosophy of it!

This pull request suggests to switch to std::string instead of raw c string for the name member of Protein. This means you don't have to allocate/deallocate "by hand" anymore for that specific member of the Protein class.

(Also, added a .gitignore file since I by mistake added to many files to the git commit at first attempt.)

Hope you like it!
