### PR TITLE
Mark printable const

### DIFF
--- a/point.cpp
+++ b/point.cpp
@@ -99,14 +99,14 @@ float Point::get_3d_distance(const Point* reference)
     return sqrt(dx*dx + dy*dy + dz*dz);
 }
 
-char* Point::printable()
+char* Point::printable() const
 {
     char* buffer = new char[256] {};
     sprintf(buffer, "[%f,%f,%f]", x, y, z);
     return buffer;
 }
 
-char* Vector::printable()
+char* Vector::printable() const
 {
     char* buffer = new char[256] {};
     sprintf(buffer, "[φ=%f°, θ=%f°, r=%f]", phi*180/M_PI, theta*180/M_PI, r);

--- a/point.h
+++ b/point.h
@@ -48,7 +48,7 @@ public:
     float magnitude();
     void scale(float new_magn);
 
-    char* printable();
+    char* printable() const;
 
     Point& operator=(Vector v);
     friend std::ostream& operator<<(std::ostream& os, const Vector& v);
@@ -79,7 +79,7 @@ public:
     };
     Vector add(Vector* v);
 
-    char* printable();
+    char* printable() const;
 
     Vector& operator=(Point p);
     friend std::ostream& operator<<(std::ostream& os, const Point& p);


### PR DESCRIPTION
- since Point|Vector ::printable does not modify 'this' state, they can be marked const
- squashes errors/warning for gcc/clion building at my machine